### PR TITLE
initial upload

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Google Form
+    url: https://docs.google.com/forms
+    about: I want to request support but don't have a GitHub account

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Google Form
-    url: https://docs.google.com/forms
+    url: https://forms.gle/x5xHTXduRHERvhhS9
     about: I want to request support but don't have a GitHub account

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -1,0 +1,76 @@
+name: Request support
+description: I need to request support from the Software Engineering Team
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is a form to request support from the University of Colorado Department of Biomedical Informatics **Software Engineering Team** (SET). [⭐ List of our services and current team members ⭐](https://cu-dbmi.github.io/set-website/about)
+
+        **This form is not meant to be a barrier to support**, it is only meant to save time and allow us to better help you by asking a standard set of questions and tracking requests in an organized way. If you already have an established contact and agreement with a specific SET developer, you can continue to communicate directly with them.
+
+        If you don't have a GitHub account, you can instead use [this Google Form](https://docs.google.com/forms), which will create an request here automatically. You can look at what support others have requested [here](https://github.com/CU-DBMI/set-intake/issues). Note that these requests are publicly visible. If you need to make a private request, please contact [Audrey Wen](mailto:audrey.wen@cuanschutz.edu) with the same info as below.
+
+  - type: input
+    id: group
+    attributes:
+      label: Group
+      description: The lab, faculty member, PI, team, org, or group this project is primarily for.
+      placeholder: e.g. Greene Lab
+
+  - type: textarea
+    id: contact
+    attributes:
+      label: Contact info
+      description: Contact and name info for key parties for the project.
+      placeholder: |
+        E.g.:
+        Casey Greene, PI, casey@greenelab.com, @caseygreene on slack
+        John Doe, project lead, john.doe@fake.com, @johndoe on slack
+
+  - type: textarea
+    id: repos
+    attributes:
+      label: Links to code
+      description: |
+        Link to any existing code you have on e.g. GitHub, GitLab, Bitbucket, etc., and provide us the appropriate permissions to view it ([invite all team members](https://cu-dbmi.github.io/set-website/about#the-team)). This will help us to proactively answer questions, estimate time, find solutions, contribute fixes, etc.
+      placeholder: |
+        E.g.:
+        https://github.com/greenelab/greenelab.com
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow
+      description: |
+        Describe your software workflow and practices. E.g.:
+        - Do you use git and GitHub for tracking code?
+        - What operating system do you use?
+        - What programming languages, package managers, and notable libraries do you use?
+        - What IDE/editor or other tools do you use?
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Work description
+      description: |
+        Describe the specific support you need from SET. E.g.:
+        - What kind of [project work](https://cu-dbmi.github.io/set-website/about#what-we-do) needs to be done?
+        - What platforms do you need to target?
+        - What is the "minimum viable product"? What are the different phases of the project?
+        - Are there HIPAA concerns?
+        - Is there a long term maintenance plan?
+
+  - type: textarea
+    id: timeline
+    attributes:
+      label: Timeline
+      description: |
+        Describe all of your hard and soft deadlines for specific parts of the support.
+
+  - type: textarea
+    id: funding
+    attributes:
+      label: Funding
+      description: |
+        Describe your funding situation in detail. The department can cover SET's costs up to a point (e.g. for small projects and tech support), but you may be asked to cover some or all of the costs with your own grant (or other) funds, especially for larger and more long-term projects.

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -9,7 +9,12 @@ body:
 
         **This form is not meant to be a barrier to support**, it is only meant to save time and allow us to better help you by asking a standard set of questions and tracking requests in an organized way. If you already have an established contact and agreement with a specific SET developer, you can continue to communicate directly with them.
 
-        If you don't have a GitHub account, you can instead use [this Google Form](https://docs.google.com/forms), which will create an request here automatically. You can look at what support others have requested [here](https://github.com/CU-DBMI/set-intake/issues). Note that these requests are publicly visible. If you need to make a private request, please contact [Audrey Wen](mailto:audrey.wen@cuanschutz.edu) with the same info as below.
+        This support request does not become a rigid, set-in-stone contract. However, we do ask that you help us keep it up to date by posting a new comment whenever there are significant changes in work or scope.
+
+        If you don't have a GitHub account, you can instead use [this Google Form](https://docs.google.com/forms), which will create an request here automatically. 
+        However, we recommend signing up for a GitHub account so you can receive [notifications](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/about-notifications) on updates to this request.
+        
+        You can look at what support others have requested [here](https://github.com/CU-DBMI/set-intake/issues). Note that these requests are publicly visible. If you need to make a private request, please contact [Audrey Wen](mailto:audrey.wen@cuanschutz.edu) with the same info as below.
 
   - type: input
     id: group

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -5,15 +5,17 @@ body:
   - type: markdown
     attributes:
       value: |
-        This is a form to request support from the University of Colorado Department of Biomedical Informatics **Software Engineering Team** (SET). [⭐ List of our services and current team members ⭐](https://cu-dbmi.github.io/set-website/about)
+        This is a form to request support from the University of Colorado Department of Biomedical Informatics **Software Engineering Team** (SET).
+
+        [⭐ List of our services and current team members ⭐](https://cu-dbmi.github.io/set-website/about)
 
         **This form is not meant to be a barrier to support**, it is only meant to save time and allow us to better help you by asking a standard set of questions and tracking requests in an organized way. If you already have an established contact and agreement with a specific SET developer, you can continue to communicate directly with them.
 
         This support request does not become a rigid, set-in-stone contract. However, we do ask that you help us keep it up to date by posting a new comment whenever there are significant changes in work or scope.
 
-        If you don't have a GitHub account, you can instead use [this Google Form](https://docs.google.com/forms), which will create a request here automatically. However, we recommend signing up for a GitHub account so you can receive [notifications](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/about-notifications) on updates to this request.
-        
-        You can look at what support others have requested [here](https://github.com/CU-DBMI/set-intake/issues). Note that these requests are publicly visible. If you need to make a private request, please contact [Audrey Wen](mailto:audrey.wen@cuanschutz.edu) with the same info as below.
+        If you don't have a GitHub account, you can instead use [this Google Form](https://forms.gle/x5xHTXduRHERvhhS9), which will create a request here automatically. However, we recommend signing up for a GitHub account so you can receive [notifications](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/about-notifications) on updates to this request.
+
+        **This request will be publicly visible after you submit it**. You can look at what support others have requested [here](https://github.com/CU-DBMI/set-intake/issues). If you need to make a private request, please contact [Audrey Wen](mailto:audrey.wen@cuanschutz.edu) with the same info as below. Or you can fill out the form but omit details that you want to keep private (such as funding), and send the missing info to Audrey directly.
 
   - type: input
     id: group
@@ -37,7 +39,7 @@ body:
     attributes:
       label: Links to code
       description: |
-        Link to any existing code you have on e.g. GitHub, GitLab, Bitbucket, etc., and provide us the appropriate permissions to view it ([invite all team members](https://cu-dbmi.github.io/set-website/about#the-team)). This will help us to proactively answer questions, estimate time, find solutions, contribute fixes, etc.
+        Link to any existing code you have on e.g. GitHub, GitLab, Bitbucket, etc., and provide us the appropriate permissions to view it ([please invite all of our team members](https://cu-dbmi.github.io/set-website/about#the-team)). This will help us to proactively answer questions, estimate time, find solutions, contribute fixes, etc.
       placeholder: |
         E.g.:
         https://github.com/greenelab/some-repo
@@ -60,9 +62,9 @@ body:
       description: |
         Describe the specific support you need from SET. E.g.:
         - What kind of [project work](https://cu-dbmi.github.io/set-website/about#what-we-do) needs to be done?
-        - What platforms do you need to target?
+        - Does the data you're handling fall under any [confidential classification](https://www.cu.edu/security/data-classification)? Critically, **does your project involve data covered by [HIPAA](https://www.cdc.gov/phlp/publications/topic/hipaa.html)**, e.g. protected health information (PHI)?
         - What is the "minimum viable product"? What are the different phases of the project?
-        - **Does your project involve data covered by [HIPAA](https://www.cdc.gov/phlp/publications/topic/hipaa.html), e.g. [protected health information](https://www.hipaajournal.com/what-is-protected-health-information/) (PHI)?**
+        - What platforms do you need to target?
         - Is there a long term maintenance plan?
 
   - type: textarea
@@ -77,4 +79,6 @@ body:
     attributes:
       label: Funding
       description: |
-        Describe your funding situation in detail. The department can cover SET's costs up to a point (e.g. for small projects and tech support), but you may be asked to cover some or all of the costs with your own grant (or other) funds, especially for larger and more long-term projects.
+        The department can cover SET's costs up to a point (e.g. for small projects and tech support), but you may be asked to cover some or all of the costs with your own grant (or other) funds, especially for larger and more long-term projects. Describe your funding situation in detail.
+
+        _Omit if you want to keep this info private_ (see note above).

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -11,8 +11,7 @@ body:
 
         This support request does not become a rigid, set-in-stone contract. However, we do ask that you help us keep it up to date by posting a new comment whenever there are significant changes in work or scope.
 
-        If you don't have a GitHub account, you can instead use [this Google Form](https://docs.google.com/forms), which will create an request here automatically. 
-        However, we recommend signing up for a GitHub account so you can receive [notifications](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/about-notifications) on updates to this request.
+        If you don't have a GitHub account, you can instead use [this Google Form](https://docs.google.com/forms), which will create a request here automatically. However, we recommend signing up for a GitHub account so you can receive [notifications](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/about-notifications) on updates to this request.
         
         You can look at what support others have requested [here](https://github.com/CU-DBMI/set-intake/issues). Note that these requests are publicly visible. If you need to make a private request, please contact [Audrey Wen](mailto:audrey.wen@cuanschutz.edu) with the same info as below.
 
@@ -41,7 +40,7 @@ body:
         Link to any existing code you have on e.g. GitHub, GitLab, Bitbucket, etc., and provide us the appropriate permissions to view it ([invite all team members](https://cu-dbmi.github.io/set-website/about#the-team)). This will help us to proactively answer questions, estimate time, find solutions, contribute fixes, etc.
       placeholder: |
         E.g.:
-        https://github.com/greenelab/greenelab.com
+        https://github.com/greenelab/some-repo
 
   - type: textarea
     id: workflow

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -63,7 +63,7 @@ body:
         - What kind of [project work](https://cu-dbmi.github.io/set-website/about#what-we-do) needs to be done?
         - What platforms do you need to target?
         - What is the "minimum viable product"? What are the different phases of the project?
-        - Are there HIPAA concerns?
+        - **Does your project involve data covered by [HIPAA](https://www.cdc.gov/phlp/publications/topic/hipaa.html), e.g. [protected health information](https://www.hipaajournal.com/what-is-protected-health-information/) (PHI)?**
         - Is there a long term maintenance plan?
 
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# set-intake
-Request support from the Software Engineering Team
+[Request support from the Software Engineering Team](https://github.com/CU-DBMI/set-intake/issues/new/choose).


### PR DESCRIPTION
We can have a Google Form automatically submit a GitHub issue fairly easy:

https://gist.github.com/anythingcodes/c68597c8e78541f703607d3cf324134a

We just make a Google Apps script to do so, and it should be okay to have a GitHub API key in there because only the editors of the form should be able to see it.

I'm also worried that having a duplicate Google Form might get out of sync with this one, so I was thinking of maybe always just redirecting to the Google Form. The downside is that for people who _do_ have a GitHub account, the issue wouldn't be created under their username, but by the Google scripts bot (but we could still ask for their GitHub handle and tag them in the issue).